### PR TITLE
add ability to install required_packages.txt with pip

### DIFF
--- a/required_packages.txt
+++ b/required_packages.txt
@@ -1,129 +1,127 @@
-Package                       Version
------------------------------ -----------
-alabaster                     0.7.12
-altair                        4.2.0
-appdirs                       1.4.4
-argon2-cffi                   21.3.0
-argon2-cffi-bindings          21.2.0
-asttokens                     2.0.5
-attrs                         21.4.0
-Babel                         2.9.1
-backcall                      0.2.0
-beautifulsoup4                4.10.0
-bleach                        4.1.0
-certifi                       2021.10.8
-cffi                          1.15.0
-charset-normalizer            2.0.12
-click                         8.1.1
-cloudpickle                   2.0.0
-colorama                      0.4.4
-commonmark                    0.9.1
-csscompressor                 0.9.5
-cycler                        0.11.0
-dask                          2022.3.0
-deap                          1.3.1
-debugpy                       1.6.0
-decorator                     5.1.1
-defusedxml                    0.7.1
-distributed                   2022.3.0
-docutils                      0.17.1
-entrypoints                   0.4
-executing                     0.8.3
-fonttools                     4.32.0
-fsspec                        2022.2.0
-future                        0.18.2
-HeapDict                      1.0.1
-idna                          3.3
-imagesize                     1.3.0
-importlib-metadata            4.11.3
-ipykernel                     6.10.0
-ipython                       8.2.0
-ipython-genutils              0.2.0
-ipywidgets                    7.7.0
-jedi                          0.18.1
-Jinja2                        3.1.1
-jsonschema                    4.4.0
-jupyter-client                7.2.1
-jupyter-core                  4.9.2
-jupyter-sphinx                0.3.2
-jupyterlab-pygments           0.1.2
-jupyterlab-widgets            1.1.0
-kiwisolver                    1.4.2
-lark-parser                   0.12.0
-locket                        0.2.1
-lxml                          4.8.0
-MarkupSafe                    2.1.1
-matplotlib                    3.5.1
-matplotlib-inline             0.1.3
-mistune                       0.8.4
-mpmath                        1.2.1
-msgpack                       1.0.3
-nbclient                      0.5.13
-nbconvert                     6.4.5
-nbformat                      5.2.0
-nest-asyncio                  1.5.4
-networkx                      2.7.1
-notebook                      6.4.10
-numexpr                       2.8.1
-numpy                         1.22.3
-packaging                     21.3
-pandas                        1.4.1
-pandocfilters                 1.5.0
-parso                         0.8.3
-partd                         1.2.0
-pharmpy-core                  0.62.0
-pickleshare                   0.7.5
-Pillow                        9.1.0
-pip                           21.1.1
-prometheus-client             0.13.1
-prompt-toolkit                3.0.28
-psutil                        5.9.0
-pure-eval                     0.2.2
-pycparser                     2.21
-Pygments                      2.11.2
-pyparsing                     3.0.7
-pyreadr                       0.4.4
-pyrsistent                    0.18.1
-pyswarms                      1.3.0
-python-dateutil               2.8.2
-pytz                          2022.1
-pytz-deprecation-shim         0.1.0.post0
-pywin32                       303
-pywinpty                      2.0.5
-PyYAML                        6.0
-pyzmq                         22.3.0
-requests                      2.27.1
-rich                          12.0.1
-scipy                         1.8.0
-Send2Trash                    1.8.0
-setuptools                    57.0.0
-six                           1.16.0
-snowballstemmer               2.2.0
-sortedcontainers              2.4.0
-soupsieve                     2.3.1
-Sphinx                        4.5.0
-sphinxcontrib-applehelp       1.0.2
-sphinxcontrib-devhelp         1.0.2
-sphinxcontrib-htmlhelp        2.0.0
-sphinxcontrib-jsmath          1.0.1
-sphinxcontrib-qthelp          1.0.3
-sphinxcontrib-serializinghtml 1.1.5
-stack-data                    0.2.0
-symengine                     0.9.2
-sympy                         1.10.1
-tblib                         1.7.0
-terminado                     0.13.3
-testpath                      0.6.0
-toolz                         0.11.2
-tornado                       6.1
-tqdm                          4.64.0
-traitlets                     5.1.1
-tzdata                        2022.1
-tzlocal                       4.1
-urllib3                       1.26.9
-wcwidth                       0.2.5
-webencodings                  0.5.1
-widgetsnbextension            3.6.0
-xmltodict                     0.12.0
-zict                          2.1.0
-zipp                          3.7.0
+alabaster===0.7.12
+altair===4.2.0
+appdirs===1.4.4
+argon2-cffi===21.3.0
+argon2-cffi-bindings===21.2.0
+asttokens===2.0.5
+attrs===21.4.0
+Babel===2.9.1
+backcall===0.2.0
+beautifulsoup4===4.10.0
+bleach===4.1.0
+certifi===2021.10.8
+cffi===1.15.0
+charset-normalizer===2.0.12
+click===8.1.1
+cloudpickle===2.0.0
+colorama===0.4.4
+commonmark===0.9.1
+csscompressor===0.9.5
+cycler===0.11.0
+dask===2022.3.0
+deap===1.3.1
+debugpy===1.6.0
+decorator===5.1.1
+defusedxml===0.7.1
+distributed===2022.3.0
+docutils===0.17.1
+entrypoints===0.4
+executing===0.8.3
+fonttools===4.32.0
+fsspec===2022.2.0
+future===0.18.2
+HeapDict===1.0.1
+idna===3.3
+imagesize===1.3.0
+importlib-metadata===4.11.3
+ipykernel===6.10.0
+ipython===8.2.0
+ipython-genutils===0.2.0
+ipywidgets===7.7.0
+jedi===0.18.1
+Jinja2===3.1.1
+jsonschema===4.4.0
+jupyter-client===7.2.1
+jupyter-core===4.9.2
+jupyter-sphinx===0.3.2
+jupyterlab-pygments===0.1.2
+jupyterlab-widgets===1.1.0
+kiwisolver===1.4.2
+lark-parser===0.12.0
+locket===0.2.1
+lxml===4.8.0
+MarkupSafe===2.1.1
+matplotlib===3.5.1
+matplotlib-inline===0.1.3
+mistune===0.8.4
+mpmath===1.2.1
+msgpack===1.0.3
+nbclient===0.5.13
+nbconvert===6.4.5
+nbformat===5.2.0
+nest-asyncio===1.5.4
+networkx===2.7.1
+notebook===6.4.10
+numexpr===2.8.1
+numpy===1.22.3
+packaging===21.3
+pandas===1.4.1
+pandocfilters===1.5.0
+parso===0.8.3
+partd===1.2.0
+pharmpy-core===0.62.0
+pickleshare===0.7.5
+Pillow===9.1.0
+pip===21.1.1
+prometheus-client===0.13.1
+prompt-toolkit===3.0.28
+psutil===5.9.0
+pure-eval===0.2.2
+pycparser===2.21
+Pygments===2.11.2
+pyparsing===3.0.7
+pyreadr===0.4.4
+pyrsistent===0.18.1
+pyswarms===1.3.0
+python-dateutil===2.8.2
+pytz===2022.1
+pytz-deprecation-shim===0.1.0.post0
+pywin32===303
+pywinpty===2.0.5
+PyYAML===6.0
+pyzmq===22.3.0
+requests===2.27.1
+rich===12.0.1
+scipy===1.8.0
+Send2Trash===1.8.0
+setuptools===58.0.0
+six===1.16.0
+snowballstemmer===2.2.0
+sortedcontainers===2.4.0
+soupsieve===2.3.1
+Sphinx===4.5.0
+sphinxcontrib-applehelp===1.0.2
+sphinxcontrib-devhelp===1.0.2
+sphinxcontrib-htmlhelp===2.0.0
+sphinxcontrib-jsmath===1.0.1
+sphinxcontrib-qthelp===1.0.3
+sphinxcontrib-serializinghtml===1.1.5
+stack-data===0.2.0
+symengine===0.9.2
+sympy===1.10.1
+tblib===1.7.0
+terminado===0.13.3
+testpath===0.6.0
+toolz===0.11.2
+tornado===6.1
+tqdm===4.64.0
+traitlets===5.1.1
+tzdata===2022.1
+tzlocal===4.1
+urllib3===1.26.9
+wcwidth===0.2.5
+webencodings===0.5.1
+widgetsnbextension===3.6.0
+xmltodict===0.12.0
+zict===2.1.0
+zipp===3.7.0


### PR DESCRIPTION
[Original required_packages.txt ](https://github.com/certara/FDA-OGD-ML/commit/9c4329f3a8ad1a00b280183343c6d87ba25eaaa8) file I setup was replaced with format that does not work for pip installation. 

This PR formats file with '===' for pip install -r required_packages.txt.