### PR TITLE
move setuptools before deap

### DIFF
--- a/required_packages.txt
+++ b/required_packages.txt
@@ -19,6 +19,7 @@ commonmark===0.9.1
 csscompressor===0.9.5
 cycler===0.11.0
 dask===2022.3.0
+setuptools===58.0.0
 deap===1.3.1
 debugpy===1.6.0
 decorator===5.1.1
@@ -94,7 +95,6 @@ requests===2.27.1
 rich===12.0.1
 scipy===1.8.0
 Send2Trash===1.8.0
-setuptools===58.0.0
 six===1.16.0
 snowballstemmer===2.2.0
 sortedcontainers===2.4.0


### PR DESCRIPTION
deap appears to install latest version of setuptools automatically, then skips installation of setuptools===58.0.0 - changing order to explicitly install appropriate setuptools version prior to deap