### PR TITLE
[DRWN-550] [DRWN-551] update penalties logic

### DIFF
--- a/src/darwin/DarwinApp.py
+++ b/src/darwin/DarwinApp.py
@@ -60,6 +60,7 @@ def _reset_global_vars():
 
 
 def _init_app(options_file: str, folder: str = None):
+    log.message("Running pyDarwin v1.1.0")
     _reset_global_vars()
 
     file_checker.reset()

--- a/src/darwin/ModelResults.py
+++ b/src/darwin/ModelResults.py
@@ -59,7 +59,7 @@ class ModelResults:
         else:
             if not self.correlation:
                 fitness += penalties['correlation']
-            if not self.condition_num > 1000:
+            if self.condition_num > 1000:
                 fitness += penalties['condition_number']
 
         fitness += model.estimated_theta_num * penalties['theta']

--- a/src/darwin/ModelResults.py
+++ b/src/darwin/ModelResults.py
@@ -59,6 +59,8 @@ class ModelResults:
         else:
             if not self.correlation:
                 fitness += penalties['correlation']
+            if not self.condition_num > 1000:
+                fitness += penalties['condition_number']
 
         fitness += model.estimated_theta_num * penalties['theta']
         fitness += model.omega_num * penalties['omega']

--- a/src/darwin/nonmem/NMEngineAdapter.py
+++ b/src/darwin/nonmem/NMEngineAdapter.py
@@ -297,14 +297,10 @@ class NMEngineAdapter(ModelEngineAdapter):
                 for this_row in range(1, num_rows):
                     row_data = corr_data[this_row]['nm:col'][:-1]
 
-                    def abs_function(t):
-                        return abs(t) > 99999
-
-                    row_data = [abs_function(float(x['#text'])) for x in row_data]
-
-                    if any(row_data):
-                        correlation = False
-                        break
+                    for x in row_data:
+                        if abs(float(x['#text'])) > 0.95:
+                            correlation = False
+                            break
 
                 if 'nm:eigenvalues' in last_estimation:
                     # if last_estimation['nm:eigenvalues'] is None:
@@ -313,7 +309,7 @@ class NMEngineAdapter(ModelEngineAdapter):
                     min_val = 9999999
 
                     for i in eigenvalues:
-                        val = float(i['#text'])
+                        val = abs(float(i['#text']))
                         if val < min_val:
                             min_val = val
                         if val > max_val:


### PR DESCRIPTION
-   The condition_number penalty is now added to fitness value if the covariance step is successful, and the value of condition_number is greater than 1000. Previously, condition_number penalty was added to fitness value only for the case when covariance is unsuccessful.
- To replace threshold value used for correlation penalty assignment to `0.95`.
