### PR TITLE
DRWN-1295 Support Python 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools==57"]
+requires = ["setuptools>=57", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,8 +21,8 @@ packages = darwin, darwin.algorithms, darwin.grid, darwin.nonmem, darwin.nlme
 python_requires = >=3.10
 install_requires =
     deap-Certara
-    numpy<1.24
-    scikit-learn<1.2
+    numpy
+    scikit-learn
     psutil
     pyswarms
     scikit-optimize<=0.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pyDarwin-Certara
-version = 2.0.1
+version = 3.0.0
 author = Mark Sale
 author_email = mark.sale@certara.com
 description = Python solution for using several machine learning methods to search a candidate solution space for the optimal population models in NONMEM

--- a/src/darwin/DarwinApp.py
+++ b/src/darwin/DarwinApp.py
@@ -114,7 +114,7 @@ def init_search(model_template: Template) -> bool:
 
 
 def _init_app(options_file: str, folder: str = None):
-    log.message("Running pyDarwin v2.0.0")
+    log.message("Running pyDarwin v3.0.0")
     _reset_global_vars()
 
     file_checker.reset()

--- a/src/darwin/algorithms/GA.py
+++ b/src/darwin/algorithms/GA.py
@@ -1,7 +1,8 @@
 from copy import copy
 import time
 import logging 
-import numpy as np 
+import numpy as np
+import warnings
 
 import darwin.GlobalVars as GlobalVars
 
@@ -17,7 +18,7 @@ from darwin.ModelRun import ModelRun
 
 from .DeapToolbox import DeapToolbox, model_run_to_deap_ind
 
-np.warnings.filterwarnings('error', category=np.VisibleDeprecationWarning)
+warnings.filterwarnings('error', category=DeprecationWarning)
 logger = logging.getLogger(__name__) 
 
 


### PR DESCRIPTION
- To remove restrictions around package versions that are incompatible with Python 3.12
- To use wheel in pyproject.toml and relax setuptools package version
- To replace np.warnings alias with warnings
- To increment version from 2.0.1 to 3.0.0

Resolves #75 