### PR TITLE
[DRWN-1640] pyDarwin can't be installed with python 3.13

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,12 +20,12 @@ package_dir =
 packages = darwin, darwin.algorithms, darwin.grid, darwin.nonmem, darwin.nlme
 python_requires = >=3.10
 install_requires =
-    deap-Certara
-    numpy<=2.0.0
-    scikit-learn<=1.5.1
+    deap
+    numpy
+    scikit-learn
     psutil
     pymoo
     pyswarms
-    scikit-optimize-Certara
+    scikit-optimize-Certara>=0.9.1
     scipy
     xmltodict


### PR DESCRIPTION
[DRWN-1383] [pyDarwin] Update deap dependency

[DRWN-1383]: https://certara.atlassian.net/browse/DRWN-1383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ