### PR TITLE
adding dry_run option for testing purposes

### DIFF
--- a/src/darwin/DarwinApp.py
+++ b/src/darwin/DarwinApp.py
@@ -119,7 +119,9 @@ def init_search(model_template: Template) -> bool:
     log.message(f"Algorithm: {options.algorithm}")
     log.message(f"Engine: {adapter.get_engine_name().upper()}")
 
-    if options.skip_running:
+    if options.dry_run:
+        log.warn('Performing a dry run')
+    elif options.skip_running:
         log.warn('Skipping model runs')
 
     if options.algorithm in ["GA", "PSO", "GBRT", "RF", "GP", "MOGA", "MOGA3"]:

--- a/src/darwin/ModelRun.py
+++ b/src/darwin/ModelRun.py
@@ -388,6 +388,15 @@ class ModelRun:
         if not keep_going():
             return
 
+        if options.dry_run:
+            self.result.calc_fitness(self.model)
+
+            self.set_status('Done')
+
+            self.result.success = True
+
+            return
+
         self.make_control_file()
 
         if not file_checker.check_files_present(self):

--- a/src/darwin/PipelineRunManager.py
+++ b/src/darwin/PipelineRunManager.py
@@ -58,6 +58,14 @@ class PipelineRunManager(ModelRunManager):
 
     @staticmethod
     def _process_run_results(run: ModelRun):
+        if options.dry_run:
+            log_run(run)
+
+            model_cache = get_model_cache()
+            model_cache.store_model_run(run)
+
+            return run
+
         this_one_is_better = (GlobalVars.best_run is None or run.result.fitness < GlobalVars.best_run.result.fitness) \
             and run.result.fitness != options.crash_value
 

--- a/src/darwin/options.py
+++ b/src/darwin/options.py
@@ -309,7 +309,8 @@ class Options:
         self.keep_extensions = opts.get('keep_extensions', [])
         self.keep_files = opts.get('keep_files', [])
 
-        self.skip_running = opts.get('skip_running', False)
+        self.dry_run = opts.get('dry_run', False)
+        self.skip_running = opts.get('skip_running', False) or self.dry_run
 
     def initialize(self, options_file, folder=None):
         if not os.path.exists(options_file):


### PR DESCRIPTION
by default set to false
when set, skips not only model running, but also run_dir creation, including model/result files
this option is undocumented and can be useful for testing exhaustive search, like finding the exact number of unique models